### PR TITLE
Share Post functionality

### DIFF
--- a/src/main/java/com/revature/Flumblr/dtos/responses/UserResponse.java
+++ b/src/main/java/com/revature/Flumblr/dtos/responses/UserResponse.java
@@ -1,0 +1,19 @@
+package com.revature.Flumblr.dtos.responses;
+
+import com.revature.Flumblr.entities.User;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class UserResponse {
+    private String id;
+    private String username;
+
+    public UserResponse (User user) {
+        this.id = user.getId();
+        this.username = user.getUsername();
+    }
+
+}

--- a/src/main/java/com/revature/Flumblr/entities/Post.java
+++ b/src/main/java/com/revature/Flumblr/entities/Post.java
@@ -65,6 +65,10 @@ public class Post {
 
     @OneToMany(mappedBy = "post", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonManagedReference
+    private Set<PostShare> postShares;
+
+    @OneToMany(mappedBy = "post", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JsonManagedReference
     private Set<PostVote> postVotes;
 
     @OneToMany(mappedBy = "post", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/revature/Flumblr/entities/User.java
+++ b/src/main/java/com/revature/Flumblr/entities/User.java
@@ -87,10 +87,12 @@ public class User {
     @JsonManagedReference
     private Set<Notification> notifications;
 
+    // users the user is following
     @OneToMany(mappedBy = "user", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonManagedReference
     private Set<Follow> follows;
 
+    // users who are following this user
     @OneToMany(mappedBy = "follow", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonManagedReference
     private Set<Follow> following;

--- a/src/main/java/com/revature/Flumblr/repositories/PostRepository.java
+++ b/src/main/java/com/revature/Flumblr/repositories/PostRepository.java
@@ -2,6 +2,8 @@ package com.revature.Flumblr.repositories;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Date;
@@ -12,9 +14,16 @@ import com.revature.Flumblr.entities.User;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, String> {
-    List<Post> findByUserIdOrderByCreateTimeDesc(String userId);
+    List<Post> findByUserId(String userId);
 
-    List<Post> findAllByUserIn(List<User> following, Pageable pageable);
+    @Query("SELECT DISTINCT p FROM Post p left join p.postShares ps " + 
+    "WHERE p.user.id = :userId OR ps.user.id = :userId "
+    + "ORDER BY p.createTime DESC")
+    List<Post> findPostsAndSharesByUserId(@Param("userId") String userId);
+
+    @Query("SELECT DISTINCT p FROM Post p left join p.postShares ps " + 
+    "WHERE p.user IN :following OR ps.user IN :following")
+    List<Post> findPostsAndSharesForUserIn(@Param("following") List<User> following, Pageable pageable);
 
     List<Post> findAllByTagsNameIn(List<String> tags, Pageable pageable);
 

--- a/src/main/java/com/revature/Flumblr/repositories/PostShareRepository.java
+++ b/src/main/java/com/revature/Flumblr/repositories/PostShareRepository.java
@@ -1,0 +1,13 @@
+package com.revature.Flumblr.repositories;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.revature.Flumblr.entities.PostShare;
+
+@Repository
+public interface PostShareRepository extends JpaRepository<PostShare, String> {
+    Optional<PostShare> findByPostIdAndUserId(String postId, String userId);
+}

--- a/src/main/java/com/revature/Flumblr/services/FollowService.java
+++ b/src/main/java/com/revature/Flumblr/services/FollowService.java
@@ -57,6 +57,8 @@ public class FollowService {
                     " already follows " + followName);
         User follower = userService.findById(userId);
         User followed = userService.findByUsername(followName);
+        if(follower.getId().equals(followed.getId()))
+            throw new ResourceConflictException("self-follow not permitted");
         Follow follow = new Follow(follower, followed);
         followRepository.save(follow);
         notificationService.createNotification("User " + follower.getUsername() + " followed you",

--- a/src/main/java/com/revature/Flumblr/services/PostShareService.java
+++ b/src/main/java/com/revature/Flumblr/services/PostShareService.java
@@ -1,0 +1,49 @@
+package com.revature.Flumblr.services;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.revature.Flumblr.entities.Post;
+import com.revature.Flumblr.entities.PostShare;
+import com.revature.Flumblr.entities.User;
+import com.revature.Flumblr.repositories.PostShareRepository;
+import com.revature.Flumblr.utils.custom_exceptions.ResourceConflictException;
+
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@Service
+public class PostShareService {
+
+    private final PostShareRepository postShareRepository;
+    private final UserService userService;
+    private final PostService postService;
+    private final NotificationService notificationService;
+    private final NotificationTypeService notificationTypeService;
+
+    public void create(String postId, String userId) {
+        Optional<PostShare> postShareOpt = postShareRepository.findByPostIdAndUserId(postId, userId);
+        if(!postShareOpt.isEmpty()) {
+            throw new ResourceConflictException("already shared Post(" + postId + ')');
+        }
+        User user = userService.findById(userId);
+        Post post = postService.findById(postId);
+        if(post.getUser().getId().equals(user.getId()))
+            throw new ResourceConflictException("Post(" + postId + ") is by sharing User(" + userId + ')');
+        PostShare postShare = new PostShare(user, post);
+        postShareRepository.save(postShare);
+        notificationService.createNotification("User " + user.getUsername() + " shared your post",
+                "post:" + post.getId(), post.getUser(), notificationTypeService.findByName("share"));
+    }
+
+    @Transactional
+    public void delete(String postId, String userId) {
+        Optional<PostShare> postShareOpt = postShareRepository.findByPostIdAndUserId(postId, userId);
+        if(postShareOpt.isEmpty()) {
+            throw new ResourceConflictException("haven't shared Post(" + postId + ')');
+        }
+        postShareRepository.delete(postShareOpt.get());
+    }
+}

--- a/src/main/resources/SQL/dml.sql
+++ b/src/main/resources/SQL/dml.sql
@@ -4,7 +4,7 @@ INSERT INTO notification_types (name,id) VALUES
 ('follow', '3'),
 ('share', '4'),
 ('profileLike', '5'),
-('commentLike', '6')
+('commentLike', '6');
 
 
 INSERT INTO themes (name,id) VALUES
@@ -13,4 +13,4 @@ INSERT INTO themes (name,id) VALUES
 ('theme-two','2'),
 ('theme-three', '3'),
 ('theme-four', '4'),
-('theme-five', '5')
+('theme-five', '5');

--- a/src/test/java/com/revature/Flumblr/controllers/PostControllerTest.java
+++ b/src/test/java/com/revature/Flumblr/controllers/PostControllerTest.java
@@ -35,6 +35,9 @@ class PostControllerTest {
     private CommentService commentService;
 
     @Mock
+    private PostShareService postShareService;
+
+    @Mock
     private S3StorageService s3StorageService;
 
     private static final String userId = "51194080-3452-4503-b271-6df469cb7983";
@@ -43,23 +46,28 @@ class PostControllerTest {
     private User user;
     private List<Comment> comments;
     private Set<PostVote> postVotes;
+    private Set<PostShare> postShares;
 
     @BeforeEach
     public void setup() {
-        postController = new PostController(tokenService, postService, commentService, s3StorageService);
+        postController = new PostController(tokenService, postService, commentService, postShareService,
+            s3StorageService);
         user = new User();
         // necessary for PostResponse
         user.setProfile(new Profile(user, null, "I'm a teapot", null));
         posts = new ArrayList<Post>();
         comments = new ArrayList<Comment>();
         postVotes = new HashSet<PostVote>();
+        postShares = new HashSet<PostShare>();
         Post addPost = new Post("testPost", null, null, user);
         addPost.setComments(comments);
         addPost.setPostVotes(postVotes);
+        addPost.setPostShares(postShares);
         posts.add(addPost);
         addPost = new Post("anotherPost", null, null, user);
         addPost.setComments(comments);
         addPost.setPostVotes(postVotes);
+        addPost.setPostShares(postShares);
         posts.add(addPost);
         when(tokenService.extractUserId("dummyToken")).thenReturn(userId);
     }
@@ -132,11 +140,11 @@ class PostControllerTest {
 
     @Test
     public void getUserPostsTest() {
-        when(postService.getUserPosts(userId)).thenReturn(posts);
+        when(postService.findUserPostsAndShares(userId)).thenReturn(posts);
 
         ResponseEntity<List<PostResponse>> result = postController.getUserPosts(userId, "dummyToken");
 
-        verify(postService, times(1)).getUserPosts(userId);
+        verify(postService, times(1)).findUserPostsAndShares(userId);
         assertEquals(result.getStatusCode(), HttpStatus.OK);
 
         List<String> resultMessages = new ArrayList<String>();
@@ -153,6 +161,7 @@ class PostControllerTest {
         Post responsePost = new Post("testPost", null, null, user);
         responsePost.setComments(comments);
         responsePost.setPostVotes(postVotes);
+        responsePost.setPostShares(postShares);
         final String postId = "c4030998-a0f5-4850-a951-fb9bfc8dcf50";
         responsePost.setId(postId);
         when(postService.findById(postId)).thenReturn(responsePost);

--- a/src/test/java/com/revature/Flumblr/services/FollowServiceTest.java
+++ b/src/test/java/com/revature/Flumblr/services/FollowServiceTest.java
@@ -51,6 +51,7 @@ class FollowServiceTest {
         followed = new User();
         unFollowed = new User();
         user.setId(userId);
+        user.setUsername("follower");
         followed.setUsername("followable");
         unFollowed.setUsername("unfollowable");
     }
@@ -105,6 +106,7 @@ class FollowServiceTest {
             "unfollowable")).thenReturn(Optional.empty());
         when(followRepository.findByUserIdAndFollowUsername(userId,
             "followable")).thenReturn(Optional.of(new Follow(user, followed)));
+        when(userService.findById(userId)).thenReturn(user);
         assertThrows(ResourceConflictException.class, ()->{
             followService.delete(userId, "unfollowable");
         });

--- a/src/test/java/com/revature/Flumblr/services/PostServiceTest.java
+++ b/src/test/java/com/revature/Flumblr/services/PostServiceTest.java
@@ -42,6 +42,8 @@ class PostServiceTest {
 
     private User followed;
 
+    private Set<PostShare> postShares;
+
     private static final String userId = "51194080-3452-4503-b271-6df469cb7983";
 
     @BeforeEach
@@ -52,6 +54,8 @@ class PostServiceTest {
         user.setId(userId);
         followed.setUsername("followable");
         post = new Post("testPost", null, null, user);
+        postShares = new HashSet<PostShare>();
+        post.setPostShares(postShares);
     }
 
     @Test
@@ -62,9 +66,9 @@ class PostServiceTest {
         user.setFollows(follows);
         List<Post> posts = new ArrayList<Post>();
         posts.add(post);
-        when(postRepository.findAllByUserIn(anyList(), isA(Pageable.class))).thenReturn(posts);
+        when(postRepository.findPostsAndSharesForUserIn(anyList(), isA(Pageable.class))).thenReturn(posts);
         postService.getFollowing(userId, 1);
-        verify(postRepository, times(1)).findAllByUserIn(anyList(), isA(Pageable.class));
+        verify(postRepository, times(1)).findPostsAndSharesForUserIn(anyList(), isA(Pageable.class));
     }
 
     @Test
@@ -92,9 +96,9 @@ class PostServiceTest {
 
     @Test
     public void getUserPostsTest () {
-        postService.getUserPosts(userId);
+        postService.findUserPostsAndShares(userId);
         verify(postRepository, times(1))
-            .findByUserIdOrderByCreateTimeDesc(userId);
+            .findPostsAndSharesByUserId(userId);
     }
 
     @Test


### PR DESCRIPTION
endpoints:
post to ```posts/share/{postId}```: share post
delete to ```posts/share/{postId}```: delete share

add 'shareCount' to ```PostResponse```: # of shares

add 'sharedBy' to ```PostResponse```: list of ```{id, username}``` (```UserResponse``` dto) of users the requester has followed who have also shared the post

Still need to add some testing

Had to do some custom jpql queries in ```PostRepository```.
another function that might need review is ```findUsersForSharesAndRequesterId``` in ```PostService```
add ```postShares``` field to ```Post``` entity